### PR TITLE
Fixed CS

### DIFF
--- a/tests/Bridge/Symfony/Resources/XliffValidatorTestCase.php
+++ b/tests/Bridge/Symfony/Resources/XliffValidatorTestCase.php
@@ -29,7 +29,7 @@ abstract class XliffValidatorTestCase extends TestCase
      */
     protected $errors = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->loader = new XliffFileLoader();
     }
@@ -37,7 +37,7 @@ abstract class XliffValidatorTestCase extends TestCase
     /**
      * @dataProvider getXliffPaths
      */
-    public function testXliff($path): void
+    public function testXliff(string $path): void
     {
         $this->validatePath($path);
 

--- a/tests/FlashMessage/FlashManagerTest.php
+++ b/tests/FlashMessage/FlashManagerTest.php
@@ -41,7 +41,7 @@ class FlashManagerTest extends TestCase
     /**
      * Set up units tests.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->session = $this->getSession();
         $this->flashManager = $this->getFlashManager([


### PR DESCRIPTION
Using this rules

```php
        PhpCsFixerCustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\NoCommentedOutCodeFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\NoLeadingSlashInGlobalNamespaceFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\NoUselessClassCommentFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\NoUselessConstructorCommentFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\NoUselessDoctrineRepositoryCommentFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\PhpdocNoSuperfluousParamFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\PhpdocParamOrderFixer::name() => true,
        PhpCsFixerCustomFixers\Fixer\PhpdocParamTypeFixer::name() => true,
````