### PR TITLE
Add support for symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "require": {
         "php": "^7.2",
         "sonata-project/doctrine-extensions": "^1.1",
-        "symfony/config": "^3.4 || ^4.0",
-        "symfony/translation": "^3.4 || ^4.0",
-        "symfony/twig-bridge": "^3.4 || ^4.3",
+        "symfony/config": "^3.4 || ^4.0 || ^5.0",
+        "symfony/translation": "^3.4 || ^4.0 || ^5.0",
+        "symfony/twig-bridge": "^3.4 || ^4.3 || ^5.0",
         "twig/twig": "^2.0"
     },
     "conflict": {
@@ -35,10 +35,10 @@
         "jms/serializer-bundle": "^3.3",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0",
-        "symfony/http-foundation": "^3.4 || ^4.0",
-        "symfony/http-kernel": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
+        "symfony/http-foundation": "^3.4 || ^4.0 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^5.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/framework-bundle": "^3.4 || ^4.0",
         "symfony/http-foundation": "^3.4 || ^4.0",
         "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/phpunit-bridge": "^4.1.4",
+        "symfony/phpunit-bridge": "^5.0",
         "symfony/twig-bridge": "^3.4 || ^4.1"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "sonata-project/doctrine-extensions": "^1.1",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/translation": "^3.4 || ^4.0",
-        "twig/extensions": "^1.5",
+        "symfony/twig-bridge": "^3.4 || ^4.3",
         "twig/twig": "^2.0"
     },
     "conflict": {
@@ -39,8 +39,7 @@
         "symfony/framework-bundle": "^3.4 || ^4.0",
         "symfony/http-foundation": "^3.4 || ^4.0",
         "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/phpunit-bridge": "^5.0",
-        "symfony/twig-bridge": "^3.4 || ^4.1"
+        "symfony/phpunit-bridge": "^5.0"
     },
     "config": {
         "sort-packages": true

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -27,8 +27,14 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sonata_twig');
+        $treeBuilder = new TreeBuilder('sonata_twig');
+
+        // NEXT_MAJOR: Remove when dropping support for symfony/config < 4.2
+        if (!method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->root('sonata_twig');
+        } else {
+            $rootNode = $treeBuilder->getRootNode();
+        }
 
         $this->addFlashMessageSection($rootNode);
 

--- a/tests/Bridge/Symfony/Bundle/SonataTwigBundleTest.php
+++ b/tests/Bridge/Symfony/Bundle/SonataTwigBundleTest.php
@@ -31,7 +31,7 @@ final class SonataTwigBundleTest extends TestCase
     {
         $containerBuilder = $this->createMock(ContainerBuilder::class);
 
-        $containerBuilder->expects($this->any())
+        $containerBuilder
             ->method('addCompilerPass')
             ->willReturnCallback(function (CompilerPassInterface $pass): void {
                 if ($pass instanceof StatusRendererCompilerPass) {

--- a/tests/Extension/FlashMessageExtensionTest.php
+++ b/tests/Extension/FlashMessageExtensionTest.php
@@ -28,8 +28,7 @@ class FlashMessageExtensionTest extends TestCase
     public function testFunctionsArePrefixed(): void
     {
         foreach ($this->extension->getFunctions() as $function) {
-            $this->assertTrue(
-                0 === strpos($function->getName(), 'sonata_flashmessages_'),
+            $this->assertSame(0, strpos($function->getName(), 'sonata_flashmessages_'),
                 'All function names should start with a standard prefix'
             );
         }

--- a/tests/Extension/StatusExtensionTest.php
+++ b/tests/Extension/StatusExtensionTest.php
@@ -15,6 +15,7 @@ namespace Sonata\Twig\Tests\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Twig\Extension\StatusExtension;
+use Twig\TwigFilter;
 
 class StatusExtensionTest extends TestCase
 {
@@ -29,6 +30,6 @@ class StatusExtensionTest extends TestCase
         $extension = new StatusExtension();
         $filters = $extension->getFilters();
 
-        $this->assertContainsOnlyInstancesOf('Twig_SimpleFilter', $filters);
+        $this->assertContainsOnlyInstancesOf(TwigFilter::class, $filters);
     }
 }

--- a/tests/Node/TemplateBoxNodeTest.php
+++ b/tests/Node/TemplateBoxNodeTest.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace Sonata\Twig\Tests\Node;
 
 use Sonata\Twig\Node\TemplateBoxNode;
+use Twig\Node\Expression\ConstantExpression;
 
 class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
 {
     public function testConstructor(): void
     {
         $body = new TemplateBoxNode(
-            new \Twig_Node_Expression_Constant('This is the default message', 1),
+            new ConstantExpression('This is the default message', 1),
             true,
             1,
             'sonata_template_box'
@@ -44,14 +45,14 @@ class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
     public function getTests()
     {
         $nodeEn = new TemplateBoxNode(
-            new \Twig_Node_Expression_Constant('This is the default message', 1),
+            new ConstantExpression('This is the default message', 1),
             true,
             1,
             'sonata_template_box'
         );
 
         $nodeFr = new TemplateBoxNode(
-            new \Twig_Node_Expression_Constant('Ceci est le message par défaut', 1),
+            new ConstantExpression('Ceci est le message par défaut', 1),
             true,
             1,
             'sonata_template_box'

--- a/tests/Node/TemplateBoxNodeTest.php
+++ b/tests/Node/TemplateBoxNodeTest.php
@@ -15,8 +15,9 @@ namespace Sonata\Twig\Tests\Node;
 
 use Sonata\Twig\Node\TemplateBoxNode;
 use Twig\Node\Expression\ConstantExpression;
+use Twig\Test\NodeTestCase;
 
-class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
+class TemplateBoxNodeTest extends NodeTestCase
 {
     public function testConstructor(): void
     {

--- a/tests/TokenParser/TemplateBoxTokenParserTest.php
+++ b/tests/TokenParser/TemplateBoxTokenParserTest.php
@@ -16,7 +16,7 @@ namespace Sonata\Twig\Tests\TokenParser;
 use PHPUnit\Framework\TestCase;
 use Sonata\Twig\Node\TemplateBoxNode;
 use Sonata\Twig\TokenParser\TemplateBoxTokenParser;
-use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Node\Expression\ConstantExpression;
 
 class TemplateBoxTokenParserTest extends TestCase
 {
@@ -31,10 +31,8 @@ class TemplateBoxTokenParserTest extends TestCase
      */
     public function testCompile($enabled, $source, $expected): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
-
         $env = new \Twig_Environment(new \Twig_Loader_Array([]), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
-        $env->addTokenParser(new TemplateBoxTokenParser($enabled, $translator));
+        $env->addTokenParser(new TemplateBoxTokenParser($enabled));
         if (class_exists('\Twig_Source')) {
             $source = new \Twig_Source($source, 'test');
         }
@@ -57,7 +55,7 @@ class TemplateBoxTokenParserTest extends TestCase
                 true,
                 '{% sonata_template_box %}',
                 new TemplateBoxNode(
-                    new \Twig_Node_Expression_Constant('Template information', 1),
+                    new ConstantExpression('Template information', 1),
                     true,
                     1,
                     'sonata_template_box'
@@ -67,7 +65,7 @@ class TemplateBoxTokenParserTest extends TestCase
                 true,
                 '{% sonata_template_box "This is the basket delivery address step page" %}',
                 new TemplateBoxNode(
-                    new \Twig_Node_Expression_Constant('This is the basket delivery address step page', 1),
+                    new ConstantExpression('This is the basket delivery address step page', 1),
                     true,
                     1,
                     'sonata_template_box'
@@ -77,7 +75,7 @@ class TemplateBoxTokenParserTest extends TestCase
                 false,
                 '{% sonata_template_box "This is the basket delivery address step page" %}',
                 new TemplateBoxNode(
-                    new \Twig_Node_Expression_Constant('This is the basket delivery address step page', 1),
+                    new ConstantExpression('This is the basket delivery address step page', 1),
                     false,
                     1,
                     'sonata_template_box'

--- a/tests/TokenParser/TemplateBoxTokenParserTest.php
+++ b/tests/TokenParser/TemplateBoxTokenParserTest.php
@@ -16,7 +16,12 @@ namespace Sonata\Twig\Tests\TokenParser;
 use PHPUnit\Framework\TestCase;
 use Sonata\Twig\Node\TemplateBoxNode;
 use Sonata\Twig\TokenParser\TemplateBoxTokenParser;
+use Twig\Environment;
+use Twig\Error\SyntaxError;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\Expression\ConstantExpression;
+use Twig\Parser;
+use Twig\Source;
 
 class TemplateBoxTokenParserTest extends TestCase
 {
@@ -24,20 +29,18 @@ class TemplateBoxTokenParserTest extends TestCase
      * @dataProvider getTestsForRender
      *
      * @param bool            $enabled
-     * @param \Twig_Source    $source
+     * @param string          $source
      * @param TemplateBoxNode $expected
      *
-     * @throws \Twig_Error_Syntax
+     * @throws SyntaxError
      */
     public function testCompile($enabled, $source, $expected): void
     {
-        $env = new \Twig_Environment(new \Twig_Loader_Array([]), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env = new Environment(new ArrayLoader([]), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
         $env->addTokenParser(new TemplateBoxTokenParser($enabled));
-        if (class_exists('\Twig_Source')) {
-            $source = new \Twig_Source($source, 'test');
-        }
+        $source = new Source($source, 'test');
         $stream = $env->tokenize($source);
-        $parser = new \Twig_Parser($env);
+        $parser = new Parser($env);
 
         $actual = $parser->parse($stream)->getNode('body')->getNode(0);
         $this->assertSame(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I've removed `twig/extensions` from the dependencies since [is deprecated](https://github.com/twigphp/Twig-extensions) and added `symfony/twig-bridge` for the `trans` function.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for Symfony 5
### Changed
- Migrated to Twig namespaces 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
