### PR TITLE
Fix some service ids

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Compiler/StatusRendererCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/StatusRendererCompilerPass.php
@@ -24,11 +24,11 @@ final class StatusRendererCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('sonata.twig.status_extension')) {
+        if (!$container->hasDefinition('sonata.twig.status_runtime')) {
             return;
         }
 
-        $definition = $container->getDefinition('sonata.twig.status_extension');
+        $definition = $container->getDefinition('sonata.twig.status_runtime');
 
         foreach ($container->findTaggedServiceIds('sonata.status.renderer') as $id => $attributes) {
             $definition->addMethodCall('addStatusService', [new Reference($id)]);

--- a/src/Bridge/Symfony/DependencyInjection/SonataTwigExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataTwigExtension.php
@@ -70,8 +70,8 @@ final class SonataTwigExtension extends Extension
         $identifier = 'sonata.twig.flashmessage.manager';
 
         $definition = $container->getDefinition($identifier);
-        $definition->replaceArgument(2, $types);
-        $definition->replaceArgument(3, $cssClasses);
+        $definition->replaceArgument(1, $types);
+        $definition->replaceArgument(2, $cssClasses);
 
         $container->setDefinition($identifier, $definition);
     }

--- a/src/Bridge/Symfony/Resources/config/flash.xml
+++ b/src/Bridge/Symfony/Resources/config/flash.xml
@@ -8,7 +8,6 @@
         <service id="sonata.twig.flashmessage.manager" class="%sonata.twig.flashmessage.manager.class%" public="true">
             <tag name="sonata.status.renderer"/>
             <argument type="service" id="session"/>
-            <argument type="service" id="translator"/>
             <argument/>
             <argument/>
         </service>

--- a/src/Bridge/Symfony/Resources/config/twig.xml
+++ b/src/Bridge/Symfony/Resources/config/twig.xml
@@ -17,7 +17,7 @@
         <service id="sonata.twig.template_extension" class="Sonata\Twig\Extension\TemplateExtension">
             <tag name="twig.extension"/>
             <argument>%kernel.debug%</argument>
-            <argument type="service" id="sonata.twig.model.adapter.chain"/>
+            <argument type="service" id="sonata.doctrine.model.adapter.chain"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

More findings, in this case StatusRuntime is the one having `addStatusService` method and `sonata.twig.model.adapter.chain` does not exists and [it was `sonata.doctrine.model.adapter.chain` in CoreBundle](https://github.com/sonata-project/SonataCoreBundle/blob/3.x/src/CoreBundle/Resources/config/twig.xml#L25).

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed wrong service ids
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
