### PR TITLE
Import flashmessage.css from CoreBundle

### DIFF
--- a/src/Bridge/Symfony/Resources/public/css/flashmessage.css
+++ b/src/Bridge/Symfony/Resources/public/css/flashmessage.css
@@ -1,0 +1,29 @@
+.read-more-state {
+    display: none;
+}
+
+.read-more-target {
+    opacity: 0;
+    display: none;
+    max-height: 0;
+    font-size: 0;
+    transition: .40s ease;
+}
+
+.read-more-state:checked ~ .read-more-wrap .read-more-target {
+    opacity: 1;
+    display: block;
+    font-size: inherit;
+    max-height: 999em;
+}
+
+.read-more-trigger {
+    cursor: pointer;
+    margin: auto;
+}
+
+.alert .read-more-trigger {
+    position: relative;
+    left: calc(50% - 1rem);
+}
+


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

While I was with https://github.com/sonata-project/SonataAdminBundle/pull/5833, I realised that some assets from CoreBundle are not imported yet by other packages. Since the twig file that shows flash messages is in this package, I added here the css file.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added flashmessage.css from CoreBundle
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
I've tagged as minor as it was a feature, but I'm not sure.