### PR TITLE
Use `Node::getNode()` with "0" as string instead of `\Iterator::offsetGet(0)`

### DIFF
--- a/tests/TokenParser/DeprecatedTemplateTokenParserTest.php
+++ b/tests/TokenParser/DeprecatedTemplateTokenParserTest.php
@@ -64,11 +64,8 @@ class DeprecatedTemplateTokenParserTest extends TestCase
         $stream = $env->tokenize($source);
         $parser = new Parser($env);
 
-        // The following original line is commented due an issue with the allowed node name types.
-        // Using `Iterator::offsetGet()` is a workaround.
+        // "0" is passed as string due an issue with the allowed node name types.
         // @see https://github.com/twigphp/Twig/issues/3294
-        // return $parser->parse($stream)->getNode('body')->getNode(0);
-
-        return $parser->parse($stream)->getNode('body')->getIterator()->offsetGet(0);
+        return $parser->parse($stream)->getNode('body')->getNode('0');
     }
 }

--- a/tests/TokenParser/TemplateBoxTokenParserTest.php
+++ b/tests/TokenParser/TemplateBoxTokenParserTest.php
@@ -42,11 +42,9 @@ class TemplateBoxTokenParserTest extends TestCase
         $stream = $env->tokenize($source);
         $parser = new Parser($env);
 
-        // The following original line is commented due an issue with the allowed node name types.
-        // Using `Iterator::offsetGet()` is a workaround.
+        // "0" is passed as string due an issue with the allowed node name types.
         // @see https://github.com/twigphp/Twig/issues/3294
-        // $actual = $parser->parse($stream)->getNode('body')->getNode(0);
-        $actual = $parser->parse($stream)->getNode('body')->getIterator()->offsetGet(0);
+        $actual = $parser->parse($stream)->getNode('body')->getNode('0');
         $this->assertSame(
             $expected->getIterator()->getFlags(),
             $actual->getIterator()->getFlags()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Use `Node::getNode()` with "0" as string instead of `\Iterator::offsetGet(0)`, since this is the suggested solution [[ref](https://github.com/twigphp/Twig/issues/3294#issuecomment-600511174)].
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #70.

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->
