### PR TITLE
Downgrade to use in Sonata 3

### DIFF
--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -47,12 +47,22 @@ final class FlashManager implements StatusClassRendererInterface
         $this->cssClasses = $cssClasses;
     }
 
-    public function handlesObject($object, ?string $statusName = null): bool
+    /**
+     * Tells if class may handle $object for status class rendering.
+     *
+     * @return bool
+     */
+    public function handlesObject($object, ?string $statusName = null)
     {
         return \is_string($object) && \array_key_exists($object, $this->cssClasses);
     }
 
-    public function getStatusClass($object, ?string $statusName = null, string $default = ''): string
+    /**
+     * Returns the status CSS class for $object.
+     *
+     * @return string
+     */
+    public function getStatusClass($object, ?string $statusName = null, string $default = '')
     {
         return \array_key_exists($object, $this->cssClasses)
             ? $this->cssClasses[$object]

--- a/src/Status/StatusClassRendererInterface.php
+++ b/src/Status/StatusClassRendererInterface.php
@@ -20,11 +20,15 @@ interface StatusClassRendererInterface
 {
     /**
      * Tells if class may handle $object for status class rendering.
+     *
+     * @return bool
      */
-    public function handlesObject(object $object, ?string $statusName = null): bool;
+    public function handlesObject(object $object, ?string $statusName = null);
 
     /**
      * Returns the status CSS class for $object.
+     *
+     * @return string
      */
-    public function getStatusClass(object $object, ?string $statusName = null, string $default = ''): string;
+    public function getStatusClass(object $object, ?string $statusName = null, string $default = '');
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of https://github.com/sonata-project/dev-kit/issues/697

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- remove return type hints in `Sonata\Twig\FlashMessage\FlashManager::handlesObject()`
- remove return type hints in `Sonata\Twig\FlashMessage\FlashManager::getStatusClass()`
- remove return type hints in `Sonata\Twig\FlashMessage\StatusClassRendererInterface::handlesObject()`
- remove return type hints in `Sonata\Twig\FlashMessage\StatusClassRendererInterface::getStatusClass()`
- remove return type hints in `Sonata\Form\Type\BaseStatusType::configureOptions()`
```