### PR TITLE
Register SonataCore twig namespace to preserve BC

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/SonataTwigExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataTwigExtension.php
@@ -16,13 +16,14 @@ namespace Sonata\Twig\Bridge\Symfony\DependencyInjection;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-final class SonataTwigExtension extends Extension
+final class SonataTwigExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -36,6 +37,18 @@ final class SonataTwigExtension extends Extension
 
         $this->registerFlashTypes($container, $config);
         $container->setParameter('sonata.twig.form_type', $config['form_type']);
+    }
+
+    /* NEXT MAJOR: Remove this logic when no one uses CoreBundle as a twig namespace */
+    public function prepend(ContainerBuilder $container)
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (!isset($bundles['SonataCoreBundle'])) {
+            $container->prependExtensionConfig('twig', ['paths' => [
+                \dirname(__DIR__).'/Resources/views' => 'SonataCore',
+            ]]);
+        }
     }
 
     /**

--- a/tests/Bridge/Symfony/DependencyInjection/SonataTwigExtensionTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/SonataTwigExtensionTest.php
@@ -18,6 +18,12 @@ use Sonata\Twig\Bridge\Symfony\DependencyInjection\SonataTwigExtension;
 
 final class SonataTwigExtensionTest extends AbstractExtensionTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', []);
+    }
+
     public function testHasFormTypeParameter(): void
     {
         $this->load();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this will help mantaining BC on 0.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Register `SonataCore` twig namespace when CoreBundle is disabled to preserve BC on all Sonata bundles
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

This prevents an error when disabling core bundle and enabling bridges:

`There are no registered paths for namespace "SonataCore" in @!SonataAdmin/standard_layout.html.twig at line 327.`

The idea is to move to SonataTwig namespace, but in the meantime, without this change, you cannot disable coreBundle. This change allows you to unregister CoreBundle without Twig errors.