### PR TITLE
Fix StatusClassRenderer implementation

### DIFF
--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -37,7 +37,7 @@ final class FlashManager implements StatusClassRendererInterface
     private $cssClasses;
 
     /**
-     * @param array $types      Sonata types array (defined in configuration)
+     * @param array $types      Sonata flash message types array (defined in configuration)
      * @param array $cssClasses Css classes associated with $types
      */
     public function __construct(SessionInterface $session, array $types, array $cssClasses)
@@ -50,22 +50,46 @@ final class FlashManager implements StatusClassRendererInterface
     /**
      * Tells if class may handle $object for status class rendering.
      *
+     * @param object|string $object     FlashManager or Sonata flash message type
+     * @param string|null   $statusName Sonata flash message type
+     *
      * @return bool
      */
     public function handlesObject($object, ?string $statusName = null)
     {
-        return \is_string($object) && \array_key_exists($object, $this->cssClasses);
+        if (\is_string($object)) {
+            if (null === $statusName) {
+                $statusName = $object;
+            }
+            $object = $this;
+        }
+
+        if (!$object instanceof self) {
+            return false;
+        }
+
+        return \array_key_exists($statusName, $this->cssClasses);
     }
 
     /**
      * Returns the status CSS class for $object.
      *
+     * @param object|string $object     FlashManager or Sonata flash message type
+     * @param string|null   $statusName Sonata flash message type
+     * @param string        $default    Default status class if flash message type do not exist
+     *
      * @return string
      */
     public function getStatusClass($object, ?string $statusName = null, string $default = '')
     {
-        return \array_key_exists($object, $this->cssClasses)
-            ? $this->cssClasses[$object]
+        if (\is_string($object)) {
+            if (null === $statusName) {
+                $statusName = $object;
+            }
+        }
+
+        return \array_key_exists($statusName, $this->cssClasses)
+            ? $this->cssClasses[$statusName]
             : $default;
     }
 

--- a/tests/Extension/StatusRuntimeTest.php
+++ b/tests/Extension/StatusRuntimeTest.php
@@ -29,6 +29,10 @@ class StatusRuntimeTest extends TestCase
             ->willReturn(false);
 
         $runtime->addStatusService($statusService);
+        // getStatusClass() for StatusClassRenderer
         $this->assertSame('test-value', $runtime->statusClass(new \stdClass(), 'getStatus', 'test-value'));
+
+        // getStatusClass() for FlashManager
+        $this->assertSame('test-value', $runtime->statusClass('getStatus', null, 'test-value'));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

After add type hints in `Sonata\Twig\Extension\StatusRuntime` get status class from string (flash massage type) is not possible and `TypeError` is throwed. This PR fix `StatusClassRendererInterface` implementation in `FlashManager` and remove some type hints which make BC-break.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #89.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix `Sonata\Twig\Status\StatusClassRendererInterface` implementation in `Sonata\Twig\FlashMessage\FlashManager`
- Fix `Sonata\Twig\Extension\StatusRuntime` to working with `Sonata\Twig\FlashMessage\FlashManager` again, after add type hints
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
