### PR TITLE
removed incorrect handlesObject call

### DIFF
--- a/src/Extension/StatusRuntime.php
+++ b/src/Extension/StatusRuntime.php
@@ -76,14 +76,12 @@ final class StatusRuntime
     private function statusClassForFlashManager(string $object, ?string $statusType = null, string $default = ''): string
     {
         if ($flashManager = $this->getFlashManagerFromStatusServices()) {
-            if ($flashManager->handlesObject($flashManager, $statusType)) {
-                if (null === $statusType) {
-                    $statusType = $object;
-                }
+            if (null === $statusType) {
+                $statusType = $object;
+            }
 
-                if ($flashManager->handlesObject($flashManager, $statusType)) {
-                    return $flashManager->getStatusClass($flashManager, $statusType, $default);
-                }
+            if ($flashManager->handlesObject($flashManager, $statusType)) {
+                return $flashManager->getStatusClass($flashManager, $statusType, $default);
             }
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix for https://github.com/sonata-project/twig-extensions/issues/93 as requested

I am targeting this branch, because the patch is needed here.

Closes #93.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

```markdown
### Fixed
- CSS Class now returned for flash messages
```
