### PR TITLE
Add `SonataTwigSymfonyBundle` in order to be compatible with Symfony Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Sonata\\Twig\\": "src/"
+            "Sonata\\Twig\\": "src/",
+            "Sonata\\Twig\\Bridge\\Symfony\\": "src/Bridge/Symfony/"
         }
     },
     "autoload-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,7 @@ parameters:
 #        - tests
 
     excludes_analyse:
+        - src/Bridge/Symfony/Bundle/SonataTwigBundle.php
         - src/Test/AbstractWidgetTestCase.php
         - tests/bootstrap.php
 

--- a/src/Bridge/Symfony/Bundle/SonataTwigBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataTwigBundle.php
@@ -13,21 +13,26 @@ declare(strict_types=1);
 
 namespace Sonata\Twig\Bridge\Symfony\Bundle;
 
-use Sonata\Twig\Bridge\Symfony\DependencyInjection\Compiler\StatusRendererCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sonata\Twig\Bridge\Symfony\SonataTwigBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * NEXT_MAJOR: remove this class.
- *
- * @deprecated since version 1.0, to be removed in 2.0. Use Sonata\Twig\Bridge\Symfony\SonataTwigBundle instead.
- *
- * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- */
-final class SonataTwigBundle extends Bundle
-{
-    public function build(ContainerBuilder $container): void
+@trigger_error(sprintf(
+    'The %s\SonataTwigBundle class is deprecated since version 1.x, to be removed in 2.0. Use %s instead.',
+    __NAMESPACE__,
+    SonataTwigBundle::class
+), E_USER_DEPRECATED);
+
+if (false) {
+    /**
+     * NEXT_MAJOR: remove this class.
+     *
+     * @deprecated since version 1.0, to be removed in 2.0. Use Sonata\Twig\Bridge\Symfony\SonataTwigBundle instead.
+     *
+     * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+     */
+    final class SonataTwigBundle extends Bundle
     {
-        $container->addCompilerPass(new StatusRendererCompilerPass());
     }
 }
+
+class_alias(SonataTwigBundle::class, __NAMESPACE__.'\SonataTwigBundle');

--- a/src/Bridge/Symfony/SonataTwigSymfonyBundle.php
+++ b/src/Bridge/Symfony/SonataTwigSymfonyBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Twig\Bridge\Symfony;
+
+// This file and its class alias is required in order to let Symfony Flex
+// autodiscovery to find the bundle.
+// The string "Symfony\Component\HttpKernel\Bundle\Bundle" must also be present.
+// @see https://github.com/symfony/flex/pull/612/files.
+class_alias(SonataTwigBundle::class, __NAMESPACE__.'\SonataTwigSymfonyBundle');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add `SonataTwigSymfonyBundle` in order to be compatible with Symfony Flex.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #97.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\Twig\Bridge\Symfony\SonataTwigSymfonyBundle`.

### Fixed
- Fixed Flex recipe implementation through `SonataTwigSymfonyBundle` alias.
```