### PR TITLE
Bump symfony to 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
     - php: '7.2'
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: '7.3'
+      env: SYMFONY=4.4.*
+    - php: '7.3'
+      env: SYMFONY=5.1.*
+    - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "require": {
         "php": "^7.2",
         "sonata-project/doctrine-extensions": "^1.5",
-        "symfony/config": "^3.4 || ^4.0 || ^5.0",
-        "symfony/translation": "^3.4 || ^4.0 || ^5.0",
-        "symfony/twig-bridge": "^3.4 || ^4.3 || ^5.0",
+        "symfony/config": "^4.4 || ^5.1",
+        "symfony/translation": "^4.4 || ^5.1",
+        "symfony/twig-bridge": "^4.4 || ^5.1",
         "twig/twig": "^2.6 || ^3.0"
     },
     "conflict": {
@@ -35,13 +35,13 @@
         "jms/serializer-bundle": "^3.3",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "symfony/browser-kit": "^3.4 || ^4.3 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
-        "symfony/framework-bundle": "^3.4.36 || ^4.3 || ^5.0",
-        "symfony/http-foundation": "^3.4 || ^4.0 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^5.0",
-        "symfony/twig-bundle": "^3.4 || ^4.3 || ^5.0"
+        "symfony/browser-kit": "^4.4 || ^5.1",
+        "symfony/dependency-injection": "^4.4 || ^5.1",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/http-foundation": "^4.4 || ^5.1",
+        "symfony/http-kernel": "^4.4 || ^5.1",
+        "symfony/phpunit-bridge": "^5.1",
+        "symfony/twig-bundle": "^4.4 || ^5.1"
     },
     "config": {
         "sort-packages": true

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -29,12 +29,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('sonata_twig');
 
-        // NEXT_MAJOR: Remove when dropping support for symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('sonata_twig');
-        } else {
-            $rootNode = $treeBuilder->getRootNode();
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addFlashMessageSection($rootNode);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Symfony 5.0 is unmaintained.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bump Symfony to version 5.1
### Removed
- Remove support of Symfony < 3.4 and < 4.4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
