### PR TITLE
Fix conflict with class names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "sonata-project/doctrine-extensions": "^1.5",
+        "sonata-project/doctrine-extensions": "^1.9",
         "symfony/config": "^4.4 || ^5.1",
         "symfony/translation": "^4.4 || ^5.1",
         "symfony/twig-bridge": "^4.4 || ^5.1",

--- a/src/Bridge/Symfony/Bundle/SonataTwigBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataTwigBundle.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\Twig\Bridge\Symfony\Bundle;
 
-use Sonata\Twig\Bridge\Symfony\SonataTwigBundle;
+use Sonata\Twig\Bridge\Symfony\SonataTwigBundle as ForwardCompatibleSonataTwigBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 @trigger_error(sprintf(
     'The %s\SonataTwigBundle class is deprecated since version 1.4, to be removed in 2.0. Use %s instead.',
     __NAMESPACE__,
-    SonataTwigBundle::class
+    ForwardCompatibleSonataTwigBundle::class
 ), E_USER_DEPRECATED);
 
 if (false) {
@@ -35,4 +35,4 @@ if (false) {
     }
 }
 
-class_alias(SonataTwigBundle::class, __NAMESPACE__.'\SonataTwigBundle');
+class_alias(ForwardCompatibleSonataTwigBundle::class, __NAMESPACE__.'\SonataTwigBundle');

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Twig\Tests\App;
 
-use Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle;
+use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\Twig\Bridge\Symfony\SonataTwigBundle;
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is a conflict with the class names.

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6264

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed conflict with class names.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
