### PR TITLE
Fixed deprecated usage of 'session' service since Symfony 5.3

### DIFF
--- a/src/Bridge/Symfony/Resources/config/flash.php
+++ b/src/Bridge/Symfony/Resources/config/flash.php
@@ -32,7 +32,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->tag('sonata.status.renderer')
             ->args([
-                new ReferenceConfigurator('session'),
+                new ReferenceConfigurator('request_stack'),
                 [],
                 [],
             ])

--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -53,7 +53,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
     {
         if ($session instanceof SessionInterface) {
             @trigger_error(sprintf(
-                'Passing "%" as $session to "%s" method is deprecated since sonata-project/twig-extensions 1.7'
+                'Passing "%s" as $session to "%s" method is deprecated since sonata-project/twig-extensions 1.7'
                 .' and will be removed in 2.0. Pass "%s" instead.',
                 SessionInterface::class,
                 __METHOD__,

--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -50,9 +50,9 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
      * @param array $types      Sonata flash message types array (defined in configuration)
      * @param array $cssClasses Css classes associated with $types
      */
-    public function __construct($session, array $types, array $cssClasses)
+    public function __construct($requestStackOrDeprecatedSession, array $types, array $cssClasses)
     {
-        if ($session instanceof SessionInterface) {
+        if ($requestStackOrDeprecatedSession instanceof SessionInterface) {
             @trigger_error(sprintf(
                 'Passing "%s" as $session to "%s" method is deprecated since sonata-project/twig-extensions 1.7'
                 .' and will be removed in 2.0. Pass "%s" instead.',
@@ -60,12 +60,12 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
                 __METHOD__,
                 RequestStack::class
             ), \E_USER_DEPRECATED);
-            $this->session = $session;
-        } elseif ($session instanceof RequestStack) {
+            $this->session = $requestStackOrDeprecatedSession;
+        } elseif ($requestStackOrDeprecatedSession instanceof RequestStack) {
             // NEXT_MAJOR: keep this block only
             // NEXT_MAJOR: add \Symfony\Component\HttpFoundation\RequestStack typehint to $session
             // NEXT_MAJOR: rename $session to $requestStack
-            $this->requestStack = $session;
+            $this->requestStack = $requestStackOrDeprecatedSession;
         } else {
             throw new \InvalidArgumentException(
                 sprintf(
@@ -73,7 +73,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
                     __METHOD__,
                     RequestStack::class,
                     SessionInterface::class,
-                    \is_object($session) ? \get_class($session) : \gettype($session)
+                    \is_object($requestStackOrDeprecatedSession) ? \get_class($requestStackOrDeprecatedSession) : \gettype($requestStackOrDeprecatedSession)
                 )
             );
         }

--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -26,6 +26,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
 {
     /**
      * @var SessionInterface|null
+     *
      * @deprecated since sonata-project/twig-extensions 1.7. Use $requestStack->getSession() instead.
      */
     private $session;

--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -53,7 +53,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
     {
         if ($session instanceof SessionInterface) {
             @trigger_error(sprintf(
-                'Passing "%" as $requestStackOrSession to "%s" method is deprecated since sonata-project/twig-extensions 1.7'
+                'Passing "%" as $session to "%s" method is deprecated since sonata-project/twig-extensions 1.7'
                 .' and will be removed in 2.0. Pass "%s" instead.',
                 SessionInterface::class,
                 __METHOD__,

--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -72,7 +72,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
                     __METHOD__,
                     RequestStack::class,
                     SessionInterface::class,
-                    is_object($session) ? get_class($session) : gettype($session)
+                    \is_object($session) ? \get_class($session) : \gettype($session)
                 )
             );
         }
@@ -163,7 +163,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
             return $this->session;
         }
 
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
+        if (method_exists($this->requestStack, 'getMainRequest')) {
             $request = $this->requestStack->getMainRequest();
         } else {
             $request = $this->requestStack->getMasterRequest();

--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -159,7 +159,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
      */
     public function getSession(): SessionInterface
     {
-        if ($this->session !== null) {
+        if (null !== $this->session) {
             return $this->session;
         }
 

--- a/tests/Extension/FlashMessageRuntimeTest.php
+++ b/tests/Extension/FlashMessageRuntimeTest.php
@@ -16,6 +16,8 @@ namespace Sonata\Twig\Tests\Extension;
 use PHPUnit\Framework\TestCase;
 use Sonata\Twig\Extension\FlashMessageRuntime;
 use Sonata\Twig\FlashMessage\FlashManager;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -60,7 +62,10 @@ class FlashMessageRuntimeTest extends TestCase
     protected function getFlashManager(array $types): FlashManager
     {
         $classes = ['error' => 'danger'];
+        $requestStack = new RequestStack();
+        $requestStack->push($request = new Request());
+        $request->setSession($this->getSession());
 
-        return new FlashManager($this->getSession(), $types, $classes);
+        return new FlashManager($requestStack, $types, $classes);
     }
 }

--- a/tests/Extension/StatusRuntimeTest.php
+++ b/tests/Extension/StatusRuntimeTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Sonata\Twig\Extension\StatusRuntime;
 use Sonata\Twig\FlashMessage\FlashManager;
 use Sonata\Twig\Status\StatusClassRendererInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -115,7 +117,10 @@ class StatusRuntimeTest extends TestCase
     protected function getFlashManager(array $types): FlashManager
     {
         $classes = ['error' => 'danger'];
+        $requestStack = new RequestStack();
+        $requestStack->push($request = new Request());
+        $request->setSession($this->session);
 
-        return new FlashManager($this->session, $types, $classes);
+        return new FlashManager($requestStack, $types, $classes);
     }
 }

--- a/tests/FlashMessage/FlashManagerTest.php
+++ b/tests/FlashMessage/FlashManagerTest.php
@@ -15,6 +15,8 @@ namespace Sonata\Twig\Tests\FlashMessage;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Twig\FlashMessage\FlashManager;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -237,7 +239,10 @@ class FlashManagerTest extends TestCase
     protected function getFlashManager(array $types): FlashManager
     {
         $classes = ['error' => 'danger'];
+        $requestStack = new RequestStack();
+        $requestStack->push($request = new Request());
+        $request->setSession($this->session);
 
-        return new FlashManager($this->session, $types, $classes);
+        return new FlashManager($requestStack, $types, $classes);
     }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC policy should have been respected.

Closes #220.

## Changelog

```markdown
### Added
- `Sonata\Twig\FlashMessage\FlashManager::$requestStack` property.

### Changed
- `Sonata\Twig\FlashMessage\FlashManager::__construct` `$session` argument allowed types for `Symfony\Component\HttpFoundation\Session\SessionInterface` or `Symfony\Component\HttpFoundation\RequestStack`
- `Sonata\Twig\FlashMessage\FlashManager::getSession()` method to fetch session from request stack
- `Sonata\Twig\FlashMessage\FlashManager` service definition to inject `'request_stack'` service instead of `'session'`

### Deprecated
- Passing `Symfony\Component\HttpFoundation\Session\SessionInterface` as $session argument of `Sonata\Twig\FlashMessage\FlashManager::__construct` 
- `Sonata\Twig\FlashMessage\FlashManager::$session` property.

### Fixed
- Usage of deprecated 'session' service since Symfony 5.3
```
