### PR TITLE
Allow customizing flashbag groups

### DIFF
--- a/src/Bridge/Symfony/Resources/views/FlashMessage/render.html.twig
+++ b/src/Bridge/Symfony/Resources/views/FlashMessage/render.html.twig
@@ -9,9 +9,11 @@ file that was distributed with this source code.
 
 #}
 
+{% set collapse = collapse|default(1) %}
+
 {% for type in sonata_flashmessages_types() %}
     {% set messages = sonata_flashmessages_get(type) %}
-    {% if messages|length > 1 %}
+    {% if messages|length > collapse and collapse > 0 %}
         <div class="alert alert-{{ sonata_flashmessages_class(type, 'default') }} alert-dismissible collapsed-box">
             <button
                     type="button"
@@ -24,7 +26,7 @@ file that was distributed with this source code.
             <input type="checkbox" class="read-more-state" id="toggle-more-{{ loop.index }}" />
             <div class="read-more-wrap">
                 {% for message in messages %}
-                    {% if loop.index >= 2 %}
+                    {% if loop.index > collapse %}
                         <span class="read-more-target">{{ message|raw }}</span>
                     {% else %}
                         {{ message|raw }}
@@ -38,17 +40,19 @@ file that was distributed with this source code.
                 <span class="badge badge-default">{{ messages|length }}</span>
             </label>
         </div>
-    {% elseif messages|length == 1 %}
-        <div class="alert alert-{{ sonata_flashmessages_class(type, 'default') }} alert-dismissable">
-            <button
+    {% elseif messages|length > 0 %}
+        {% for message in messages %}
+            <div class="alert alert-{{ sonata_flashmessages_class(type, 'default') }} alert-dismissable">
+                <button
                     type="button"
                     class="close"
                     data-dismiss="alert"
                     aria-hidden="true"
                     aria-label="{{ 'message_close'|trans({}, 'SonataTwigBundle') }}">
-                &times;
-            </button>
-            {{ messages|first|raw }}
-        </div>
+                    &times;
+                </button>
+                {{ message|raw }}
+            </div>
+        {% endfor %}
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Allow disabling / customizing flashbag:

```twig
    {% include '@SonataTwig/FlashMessage/render.html.twig' with { 'collapse': 5 } %}
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Allow customizing flashbag groups
```

