### PR TITLE
Deprecate sonata_urlsafeid in favor of SonataAdminBundle

### DIFF
--- a/src/Extension/TemplateExtension.php
+++ b/src/Extension/TemplateExtension.php
@@ -26,11 +26,15 @@ final class TemplateExtension extends AbstractExtension
     protected $debug;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var AdapterInterface
      */
     protected $modelAdapter;
 
     /**
+     * NEXT_MAJOR: Remove the second argument.
+     *
      * @param bool             $debug        Is Symfony debug enabled?
      * @param AdapterInterface $modelAdapter A Sonata model adapter
      */
@@ -40,6 +44,9 @@ final class TemplateExtension extends AbstractExtension
         $this->modelAdapter = $modelAdapter;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getFilters(): array
     {
         return [
@@ -55,10 +62,21 @@ final class TemplateExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/twig-extensions 1.7, to be removed in 2.0.
+     *
      * @param object $model
      */
     public function getUrlsafeIdentifier($model): ?string
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/twig-extension 1.7 in favor of the "sonata_urlsafeid"'
+            .' Twig filter defined by SonataAdminBundle and will be removed in version 2.0.'
+            .' You can solve this deprecation by enabling this bundle before SonataAdminBundle.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
+
         return $this->modelAdapter->getUrlsafeIdentifier($model);
     }
 

--- a/tests/Extension/TemplateExtensionTest.php
+++ b/tests/Extension/TemplateExtensionTest.php
@@ -19,6 +19,11 @@ use Sonata\Twig\Extension\TemplateExtension;
 
 class TemplateExtensionTest extends TestCase
 {
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testSafeUrl(): void
     {
         $adapter = $this->createMock(AdapterInterface::class);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Closes https://github.com/sonata-project/SonataAdminBundle/issues/7068.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `sonata_urlsafeid` filter
```