### PR TITLE
Add Dutch (NL) translations

### DIFF
--- a/src/Bridge/Symfony/Resources/translations/SonataTwigBundle.nl.xliff
+++ b/src/Bridge/Symfony/Resources/translations/SonataTwigBundle.nl.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="message_close">
+        <source>message_close</source>
+        <target>Sluiten</target>
+      </trans-unit>
+      <trans-unit id="more">
+        <source>more</source>
+        <target>meer</target>
+      </trans-unit>
+      <trans-unit id="less">
+        <source>less</source>
+        <target>minder</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
## Add Dutch (NL) translations

While working on our Dutch projects, I see missing translations in the Symfony toolbar, coming from the SonataTwigBundle domain. It would be great if Dutch translations could also be added to the project.

I am targeting this branch, because this is a useful addition. There are no BC breaks.

## Changelog

```markdown
### Added
- Added Dutch (NL) translations as xliff file.
```