### PR TITLE
Remove phpunit-bridge 5.3 and fix builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/framework-bundle": "^4.4 || ^5.3 || ^6.0",
         "symfony/http-foundation": "^4.4 || ^5.3 || ^6.0",
         "symfony/http-kernel": "^4.4.13 || ^5.3 || ^6.0",
-        "symfony/phpunit-bridge": "^5.3 || ^6.0",
+        "symfony/phpunit-bridge": "^6.0",
         "symfony/twig-bundle": "^4.4 || ^5.3 || ^6.0",
         "vimeo/psalm": "^4.7.2"
     },

--- a/src/Bridge/Symfony/Bundle/SonataTwigBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataTwigBundle.php
@@ -23,10 +23,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class SonataTwigBundle extends Bundle
 {
-    /**
-     * @return string
-     */
-    public function getPath()
+    public function getPath(): string
     {
         return __DIR__.'/..';
     }
@@ -36,10 +33,7 @@ final class SonataTwigBundle extends Bundle
         $container->addCompilerPass(new StatusRendererCompilerPass());
     }
 
-    /**
-     * @return string
-     */
-    protected function getContainerExtensionClass()
+    protected function getContainerExtensionClass(): string
     {
         return SonataTwigExtension::class;
     }

--- a/src/FlashMessage/FlashManager.php
+++ b/src/FlashMessage/FlashManager.php
@@ -177,6 +177,7 @@ final class FlashManager implements FlashManagerInterface, StatusClassRendererIn
         if (method_exists($this->requestStackOrDeprecatedSession, 'getMainRequest')) {
             $request = $this->requestStackOrDeprecatedSession->getMainRequest();
         } else {
+            // @phpstan-ignore-next-line
             $request = $this->requestStackOrDeprecatedSession->getMasterRequest();
         }
 

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -24,7 +24,6 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 
 final class AppKernel extends Kernel
 {
@@ -64,9 +63,9 @@ final class AppKernel extends Kernel
     }
 
     /**
-     * TODO: Drop RouteCollectionBuilder when support for Symfony < 5.1 is dropped.
+     * TODO: Add typehint when support for Symfony < 5.1 is dropped.
      *
-     * @param RoutingConfigurator|RouteCollectionBuilder $routes
+     * @param RoutingConfigurator $routes
      */
     protected function configureRoutes($routes): void
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

Part of: https://github.com/sonata-project/dev-kit/issues/1675