### PR TITLE
Add deprecations related to https://github.com/sonata-project/twig-extensions/pull/317

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Compiler/StatusRendererCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/StatusRendererCompilerPass.php
@@ -19,6 +19,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * NEXT_MAJOR: Remove this compiler pass.
+ *
+ * @deprecated Since version 1.x, to be removed in 2.0.
  */
 final class StatusRendererCompilerPass implements CompilerPassInterface
 {

--- a/src/Extension/StatusRuntime.php
+++ b/src/Extension/StatusRuntime.php
@@ -37,6 +37,8 @@ final class StatusRuntime
     }
 
     /**
+     * NEXT_MAJOR: Restrict $object to object.
+     *
      * @param object|string $object     Object for StatusClassRenderer or string for FlashManager
      * @param string|null   $statusType Object status type or Sonata flash message type
      * @param string        $default    Default status class
@@ -59,16 +61,16 @@ final class StatusRuntime
             return $this->statusClassForStatusClassRenderer($object, $statusType, $default);
         }
 
-        if (\is_string($object)) {
-            return $this->statusClassForFlashManager($object, $statusType, $default);
-        }
-
         // NEXT_MAJOR: Throw an exception instead.
         @trigger_error(sprintf(
-            'Passing other type than object or string as argument 1 for "%s()" is deprecated since sonata-project/twig-extensions 1.4'
+            'Passing other type than object as argument 1 for "%s()" is deprecated since sonata-project/twig-extensions 1.x'
             .' and will throw an exception in 2.0.',
             __METHOD__
         ), \E_USER_DEPRECATED);
+
+        if (\is_string($object)) {
+            return $this->statusClassForFlashManager($object, $statusType, $default);
+        }
 
         return $default;
     }

--- a/tests/Extension/StatusRuntimeTest.php
+++ b/tests/Extension/StatusRuntimeTest.php
@@ -58,6 +58,11 @@ final class StatusRuntimeTest extends TestCase
         ]);
     }
 
+    /**
+     * NEXT_MAJOR: Remove group legacy.
+     *
+     * @group legacy
+     */
     public function testStatusClassDefaultValue(): void
     {
         $runtime = new StatusRuntime();
@@ -71,7 +76,7 @@ final class StatusRuntimeTest extends TestCase
         // getStatusClass() for StatusClassRenderer
         static::assertSame('test-value', $runtime->statusClass(new \stdClass(), 'getStatus', 'test-value'));
 
-        // getStatusClass() for FlashManager
+        // NEXT_MAJOR: Remove this line.
         static::assertSame('test-value', $runtime->statusClass('getStatus', null, 'test-value'));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing a string to StatusRuntime::statusClass
- StatusRendererCompilerPass
```
