### PR TITLE
Drop support of Symfony 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "sonata-project/doctrine-extensions": "^1.9.1",
-        "symfony/config": "^4.4 || ^5.3 || ^6.0",
-        "symfony/translation": "^4.4 || ^5.3 || ^6.0",
-        "symfony/twig-bridge": "^4.4 || ^5.3 || ^6.0",
+        "symfony/config": "^4.4 || ^5.4 || ^6.0",
+        "symfony/translation": "^4.4 || ^5.4 || ^6.0",
+        "symfony/twig-bridge": "^4.4 || ^5.4 || ^6.0",
         "twig/twig": "^2.6 || ^3.0"
     },
     "require-dev": {
@@ -41,13 +41,13 @@
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
         "rector/rector": "^0.12",
-        "symfony/browser-kit": "^4.4 || ^5.3 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.3 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.3 || ^6.0",
-        "symfony/http-kernel": "^4.4.13 || ^5.3 || ^6.0",
-        "symfony/phpunit-bridge": "^6.0",
-        "symfony/twig-bundle": "^4.4 || ^5.3 || ^6.0",
+        "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4.13 || ^5.4 || ^6.0",
+        "symfony/phpunit-bridge": "^6.1",
+        "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.0",
         "vimeo/psalm": "^4.7.2"
     },
     "conflict": {


### PR DESCRIPTION
## Subject

Support only maintained versions of Symfony

I am targeting this branch, because these changes are BC.

## Changelog

```markdown
### Removed
- Support of Symfony 5.3
```