### PR TITLE
Drop sf 6.0 and 6.1, update psalm to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "homepage": "https://docs.sonata-project.org/projects/twig-extensions",
     "require": {
         "php": "^8.0",
-        "symfony/config": "^5.4 || ^6.0",
-        "symfony/twig-bridge": "^5.4 || ^6.0",
+        "symfony/config": "^5.4 || ^6.2",
+        "symfony/twig-bridge": "^5.4 || ^6.2",
         "twig/twig": "^3.0"
     },
     "require-dev": {
@@ -36,18 +36,18 @@
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "psalm/plugin-phpunit": "^0.16",
-        "psalm/plugin-symfony": "^4.0",
+        "psalm/plugin-phpunit": "^0.18",
+        "psalm/plugin-symfony": "^4.0 || ^5.0",
         "rector/rector": "^0.15",
-        "symfony/browser-kit": "^5.4 || ^6.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0",
-        "symfony/framework-bundle": "^5.4 || ^6.0",
-        "symfony/http-foundation": "^5.4 || ^6.0",
-        "symfony/http-kernel": "^5.4 || ^6.0",
-        "symfony/phpunit-bridge": "^6.1",
-        "symfony/translation": "^5.4 || ^6.0",
-        "symfony/twig-bundle": "^5.4 || ^6.0",
-        "vimeo/psalm": "^4.7.2"
+        "symfony/browser-kit": "^5.4 || ^6.2",
+        "symfony/dependency-injection": "^5.4 || ^6.2",
+        "symfony/framework-bundle": "^5.4 || ^6.2",
+        "symfony/http-foundation": "^5.4 || ^6.2",
+        "symfony/http-kernel": "^5.4 || ^6.2",
+        "symfony/phpunit-bridge": "^6.2",
+        "symfony/translation": "^5.4 || ^6.2",
+        "symfony/twig-bundle": "^5.4 || ^6.2",
+        "vimeo/psalm": "^4.7.2 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="3" findUnusedPsalmSuppress="true" findUnusedBaselineEntry="true" findUnusedCode="false" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
+<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="2" findUnusedPsalmSuppress="true" findUnusedBaselineEntry="true" findUnusedCode="false" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
     <projectFiles>
         <directory name="src"/>
         <directory name="tests"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="3" findUnusedPsalmSuppress="true" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
+<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="3" findUnusedPsalmSuppress="true" findUnusedBaselineEntry="true" findUnusedCode="false" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
     <projectFiles>
         <directory name="src"/>
         <directory name="tests"/>

--- a/src/TokenParser/TemplateBoxTokenParser.php
+++ b/src/TokenParser/TemplateBoxTokenParser.php
@@ -18,6 +18,9 @@ use Twig\Node\Expression\ConstantExpression;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
+/**
+ * @psalm-suppress PropertyNotSetInConstructor $this->parser is set by twig using setParser.
+ */
 final class TemplateBoxTokenParser extends AbstractTokenParser
 {
     /**


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/twig-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is Bc.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/twig-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Drop support for Symfony 6.0 and 6.1.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
