### PR TITLE
Drop psalm 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "phpstan/phpstan-symfony": "^1.0",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.18",
-        "psalm/plugin-symfony": "^4.0 || ^5.0",
+        "psalm/plugin-symfony": "^5.0",
         "rector/rector": "^0.15",
         "symfony/browser-kit": "^5.4 || ^6.2",
         "symfony/dependency-injection": "^5.4 || ^6.2",
@@ -47,7 +47,7 @@
         "symfony/phpunit-bridge": "^6.2",
         "symfony/translation": "^5.4 || ^6.2",
         "symfony/twig-bundle": "^5.4 || ^6.2",
-        "vimeo/psalm": "^4.7.2 || ^5.0"
+        "vimeo/psalm": "^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Pedantic, when symfony 4.4 support is dropped, psalm 4 can be dropped too.